### PR TITLE
Use user's home directory as datadir in snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@
 *.exe
 *.out
 *.app
+
+# Snap
+reden*.snap
+reden_source.tar.bz2

--- a/snap/reden-qt.wrapper
+++ b/snap/reden-qt.wrapper
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+HOMEDIR=$(getent passwd $USER | cut -d ':' -f 6)
+DATADIR=$HOMEDIR/reden
+
+mkdir -p $DATADIR
+$SNAP/bin/reden-qt -datadir=$DATADIR "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,13 +25,14 @@ apps:
       - network
 
   reden-qt:
-    command: desktop-launch $SNAP/bin/reden-qt -datadir=$SNAP_USER_COMMON
+    command: desktop-launch $SNAP/bin/reden-qt.wrapper
     desktop: reden-qt.desktop
     plugs:
       - desktop
-      - x11
+      - home
       - network
       - network-bind
+      - x11
 
 parts:
   ppa:
@@ -51,6 +52,7 @@ parts:
     configflags: [--disable-tests, --disable-bench]
     override-build: |
       snapcraftctl build
+      cp /root/build_reden/snap/reden-qt.wrapper $SNAPCRAFT_PART_INSTALL/bin/reden-qt.wrapper
       cp contrib/debian/reden-qt.desktop.desktop $SNAPCRAFT_PART_INSTALL/reden-qt.desktop
       sed -i -e 's/Icon=reden128/Icon=${SNAP}\/meta\/gui\/reden-qt.png/; s/reden-qt.desktop/Reden Core/' $SNAPCRAFT_PART_INSTALL/reden-qt.desktop
     build-packages:


### PR DESCRIPTION
We added the configuration for the Reden snap a few days ago (see pull request #29). This woks but can **potentially lead to important data loss**.

Snaps store their data in a confined directory, this directory is removed when you uninstall the snap. While this is a clean and safe design (no write access outside this confined space is needed) this might not be the best option for a cryptocurrency wallet.

If the user accidentally removes the snap it **will remove their private keys** without asking for confirmation. In other words: it's too easy to loose your most important data.

I therefore propose to create a `reden` directory in the user's home directory and use that directory as the wallet's `datadir`.

PS: You are all crypto literate enough to understand you should _always_ backup you wallet file! I don't guarantee this will work perfectly on a first try on all possible Linux distros. Trust but verify!

This means the snap will have read and write access to your homedir (excluding hidden files and directories) but also means you'll keep the full blockchain and `wallet.dat` if theReden snap is uninstalled.

> **WARNING** You are all crypto literate enough to understand you should _always_ backup your wallet file! I do not guarantee this works perfectly on all possible Linux distros. Trust but verify!