### PR TITLE
Allow snap to write to user's homedir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@
 *.exe
 *.out
 *.app
+
+# Snap
+reden*.snap
+reden_source.tar.bz2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,13 +25,14 @@ apps:
       - network
 
   reden-qt:
-    command: desktop-launch $SNAP/bin/reden-qt -datadir=$SNAP_USER_COMMON
+    command: desktop-launch $SNAP/bin/reden-qt
     desktop: reden-qt.desktop
     plugs:
       - desktop
-      - x11
+      - home
       - network
       - network-bind
+      - x11
 
 parts:
   ppa:


### PR DESCRIPTION
The Reden snap (added in pull request #29) has no access to the user's homedir. This is annoying as it means users can't backup their wallet file outside of the confined snap directory.

We don't want to make it difficult to backup your wallet.

This pull request adds homedir read/write access for the Reden snap. The Reden Qt data directory is still the default `common` directory within the snap but, with this change, you can choose to store it somewhere in your homedir as well. I feel this has the best of both worlds: it's standard snap behaviour (doesn't pollute anything outside the snap unless you tell it to) but still allows users to change the default at boostrap.

> Always backup your `wallet.dat` file in a save location, it contains all the secrets needed to restore your wallet if something goes wrong!

References #31 (background discussion on the expected snap behaviour).